### PR TITLE
Fixed TriggerByCommand and allowed arbitrary attribute to be set (lower level API access)

### DIFF
--- a/Motorola.Test/Program.cs
+++ b/Motorola.Test/Program.cs
@@ -121,9 +121,10 @@ namespace Motorola.Test
                 //GetAttributes(scanner);
 
                 //PerformCommands(scanner);
-                scanner.Trigger.TriggerByCommand = true;
-                scanner.Trigger.PullTrigger();
+                //scanner.Trigger.TriggerByCommand = true;
+                //scanner.Trigger.PullTrigger();
 
+                scanner.Actions.SetAttribute(138, 'B', 0); // sound beeper via attribute
             }
         }
 

--- a/Motorola.Test/Program.cs
+++ b/Motorola.Test/Program.cs
@@ -20,7 +20,7 @@ namespace Motorola.Test
         private static void GetAttributes(IMotorolaBarcodeScanner scanner)
         {
             //TestStatus(scanner);
-            TestOcr(scanner);
+            //TestOcr(scanner);
 
             //TestDiscovery(scanner);
             //TestImaging(scanner);
@@ -34,7 +34,7 @@ namespace Motorola.Test
             //TestCode39(scanner);
             //TestCode11(scanner);
             //TestCode93(scanner);
-            TestI2Of5(scanner);
+            //TestI2Of5(scanner);
 
             //TestD2Of5(scanner);
             //TestSecurity(scanner);
@@ -118,9 +118,12 @@ namespace Motorola.Test
 
                 //scanner.Defaults.Restore();
                 //scanner.CaptureMode = CaptureMode.Barcode;
-                GetAttributes(scanner);
+                //GetAttributes(scanner);
 
                 //PerformCommands(scanner);
+                scanner.Trigger.TriggerByCommand = true;
+                scanner.Trigger.PullTrigger();
+
             }
         }
 

--- a/MotorolaSnapi/Commands/Actions.cs
+++ b/MotorolaSnapi/Commands/Actions.cs
@@ -17,6 +17,9 @@ namespace Motorola.Snapi.Commands
 
         private readonly int _scannerId;
 
+        private readonly string _setAttributeXml;
+
+
         /// <summary>
         ///     Instantiates a new Actions object
         /// </summary>
@@ -26,6 +29,10 @@ namespace Motorola.Snapi.Commands
         {
             _scannerDriver = scannerDriver;
             _scannerId = scannerId;
+
+            _setAttributeXml =
+                $@"<inArgs><scannerID>{_scannerId}</scannerID><cmdArgs><arg-xml><attrib_list><attribute><id>{{0}}</id><datatype>{{1}}</datatype><value>{{2}}</value></attribute></attrib_list></arg-xml></cmdArgs></inArgs>";
+
         }
 
         /// <summary>
@@ -54,6 +61,22 @@ namespace Motorola.Snapi.Commands
             var s = (StatusCode)status;
             if (s != StatusCode.Success)
                 throw new ScannerException(s);
+        }
+
+        public void SetAttribute(uint attributeNumber, char type, string value)
+        {
+            var inXml = string.Format(_setAttributeXml, attributeNumber, type, value);
+            string outXml;
+            int status;
+            _scannerDriver.ExecCommand((int)ScannerCommand.DeviceSetParameters, ref inXml, out outXml, out status);
+            var s = (StatusCode)status;
+            if (s != StatusCode.Success)
+                throw new ScannerException(s);
+
+        }
+        public void SetAttribute(uint attributeNumber, char type, int value)
+        {
+            this.SetAttribute(attributeNumber, type, value.ToString());
         }
     }
 

--- a/MotorolaSnapi/Commands/Trigger.cs
+++ b/MotorolaSnapi/Commands/Trigger.cs
@@ -37,7 +37,7 @@ namespace Motorola.Snapi.Commands
             {
                 if (value)
                 {
-                    var inXml = string.Format(_setAttributeXml, "X", 0);
+                    var inXml = string.Format(_setAttributeXml, (int)Constants.AttributeNumbers.ActionAttribute.HostTriggerSession, "X", 0);
                     string outXml;
                     int status;
                     _scannerDriver.ExecCommand((int)ScannerCommand.DeviceSetParameters, ref inXml, out outXml, out status);

--- a/MotorolaSnapi/Constants/AttributeNumbers/ActionAttribute.cs
+++ b/MotorolaSnapi/Constants/AttributeNumbers/ActionAttribute.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Motorola.Snapi.Constants.AttributeNumbers
+{
+    internal enum ActionAttribute : ushort
+    {
+        BeeperLED = 6000,
+        ParameterDefaults = 6001,
+        ParameterBuffer = 6002,
+        BeepOnNextBootup = 6003,
+        Reboot = 6004,
+        HostTriggerSession = 6005
+    }
+}

--- a/MotorolaSnapi/Motorola.Snapi.csproj
+++ b/MotorolaSnapi/Motorola.Snapi.csproj
@@ -83,6 +83,7 @@
     <Compile Include="BarcodeScannerManager.cs" />
     <Compile Include="Commands\MacroPdf.cs" />
     <Compile Include="Commands\Trigger.cs" />
+    <Compile Include="Constants\AttributeNumbers\ActionAttribute.cs" />
     <Compile Include="Constants\AttributeNumbers\AdfAttribute.cs" />
     <Compile Include="Constants\AttributeNumbers\BeeperAttribute.cs" />
     <Compile Include="Constants\AttributeNumbers\Chinese2Of5Attribute.cs" />


### PR DESCRIPTION
As above.  Implemented because I have a DS457 and I wanted to change the trigger mode  (see the [integration guide for this specific scanner, page 73](https://portal.motorolasolutions.com/Support/US-EN/Resolution?solutionId=97477&productDetailGUID=210e4a4651a30410VgnVCM10000081c7b10aRCRD&detailChannelGUID=e5576e203763e310VgnVCM1000000389bd0aRCRD)), and manually trigger scans, but was unable to do so.
